### PR TITLE
ci: use fortify/3rdparty-actions wrappers

### DIFF
--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -1,4 +1,4 @@
-﻿on: 
+on: 
   push: 
     branches:
       - '**'
@@ -47,7 +47,7 @@ jobs:
           path: ${{ env.DIST_DIR }}
           
       - name: Update development release tag
-        uses: richardsimko/update-tag@aab2434e9a5040687874aa39d1c6377ec0cb0d94
+        uses: fortify/3rdparty-actions/actions/richardsimko/update-tag/v1@main
         if: env.DO_RELEASE
         with:
           tag_name: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -21,7 +21,7 @@ jobs:
       
       - name: Generate and process release PR
         id: release_please
-        uses: googleapis/release-please-action@v4
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v4@main
         with:
           release-type: simple
           


### PR DESCRIPTION
Update supported workflow actions to use the shared fortify/3rdparty-actions wrappers,