### PR TITLE
ci: update release-please action from v4 to v5

### DIFF
--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -21,7 +21,7 @@ jobs:
       
       - name: Generate and process release PR
         id: release_please
-        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v4@main
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         with:
           release-type: simple
           


### PR DESCRIPTION
Updates the googleapis/release-please-action reference in the CI workflow from v4 to v5.